### PR TITLE
Fix: Replace postfix to prefix

### DIFF
--- a/src/main/java/br/net/gmj/nobookie/LTItemMail/listener/MailboxVirtualListener.java
+++ b/src/main/java/br/net/gmj/nobookie/LTItemMail/listener/MailboxVirtualListener.java
@@ -244,9 +244,9 @@ public final class MailboxVirtualListener implements Listener {
 			event.setCancelled(true);
 		} else {
 			Integer sent_count = playerFrom.getMailSentCount();
-			DatabaseModule.User.setSentCount(playerFrom.getUniqueId(), sent_count++);
+			DatabaseModule.User.setSentCount(playerFrom.getUniqueId(), ++sent_count);
 			Integer received_count = playerTo.getMailReceivedCount();
-			DatabaseModule.User.setReceivedCount(playerTo.getUniqueId(), received_count++);
+			DatabaseModule.User.setReceivedCount(playerTo.getUniqueId(), ++received_count);
 		}
 	}
 }


### PR DESCRIPTION
Replace postfix increment with prefix increment, as the postfix passes the value to the function before the increment takes place, and therefore the updated value is not stored.